### PR TITLE
feat: add flow sync_payments_of_account

### DIFF
--- a/bunq_ynab_connect/data/storage/abstract_storage.py
+++ b/bunq_ynab_connect/data/storage/abstract_storage.py
@@ -241,10 +241,3 @@ class AbstractStorage(ABC):
         """
         rows = self.get(table)
         return self.rows_to_entities(rows, fn, as_json)
-
-    def get_budget_ids(self) -> List[str]:
-        """
-        Get a list of all budget ids
-        """
-        ynab_budgets = self.find("ynab_budgets")
-        return [budget["id"] for budget in ynab_budgets]

--- a/bunq_ynab_connect/main.py
+++ b/bunq_ynab_connect/main.py
@@ -41,7 +41,7 @@ def cli():
 
 @cli.command()
 def extract():
-    """
+    """ 
     Run all extractors.
     """
     extractors = [
@@ -61,7 +61,7 @@ def sync_payments():
     Sync payments from bunq to YNAB.
     """
     syncer = PaymentSyncer()
-    syncer.sync()
+    syncer.sync_queue()
 
 
 @cli.command()

--- a/bunq_ynab_connect/models/bunq_account.py
+++ b/bunq_ynab_connect/models/bunq_account.py
@@ -1,8 +1,10 @@
 from typing import Optional
 
+from kink import inject
 from pydantic import BaseModel, validator
 from pydantic.dataclasses import dataclass
 
+from bunq_ynab_connect.data.storage.abstract_storage import AbstractStorage
 from bunq_ynab_connect.helpers.general import date_to_datetime
 
 
@@ -37,4 +39,16 @@ class BunqAccount(BaseModel):
         for a in self.alias:
             if a["type"] == "IBAN":
                 return a["value"]
+        return None
+
+    @staticmethod
+    @inject
+    def by_iban(storage: AbstractStorage, iban: str) -> Optional["BunqAccount"]:
+        """
+        Get a Bunq account by IBAN.
+        """
+        accounts = storage.get_as_entity("bunq_accounts", BunqAccount, False)
+        for account in accounts:
+            if account.iban == iban:
+                return account
         return None

--- a/bunq_ynab_connect/models/ynab_budget.py
+++ b/bunq_ynab_connect/models/ynab_budget.py
@@ -1,9 +1,11 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
+from kink import inject
 from pydantic import BaseModel, validator
 from pydantic.dataclasses import dataclass
 
+from bunq_ynab_connect.data.storage.abstract_storage import AbstractStorage
 from bunq_ynab_connect.helpers.general import date_to_datetime
 
 
@@ -24,3 +26,11 @@ class YnabBudget(BaseModel):
     _convert_dates = validator("first_month", "last_month", allow_reuse=True, pre=True)(
         date_to_datetime
     )
+
+    @staticmethod
+    def get_budget_ids(storage: AbstractStorage) -> List[str]:
+        """
+        Get all budget ids from the storage.
+        """
+        ynab_budgets = storage.find("ynab_budgets")
+        return [budget["id"] for budget in ynab_budgets]

--- a/bunq_ynab_connect/prefect.yaml
+++ b/bunq_ynab_connect/prefect.yaml
@@ -53,6 +53,15 @@ deployments:
       name: docker-pool
       work_queue_name: default
     schedules: {}
+  - name: sync_payments_of_account
+    version: 2024.08.10.1
+    description: Force sync payemnts of an iban within a date range
+    entrypoint: flows:sync_payments_of_account
+    parameters: {}
+    work_pool:
+      name: docker-pool
+      work_queue_name: default
+    schedules: {}
   - name: train
     version: 2023.09.29.1
     description: Train one classifier for each budget

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,7 @@ This page lists some commands often used during development. Some of these will 
     - Build for one architecture: `docker buildx build --platform linux/arm64 -f docker/Dockerfile .`
 
 # Development
-- `[Untill fixed with ruff]` Remove unused imports: `autoflake --in-place --remove-unused-variables --recursive .`.
+- `[Untill fixed with ruff]` Remove unused imports: `autoflake --in-place --remove-unused-variables --recursive .`
+- Delete old mlfow runs: `mlflow gc --backend-store-uri sqlite:////mlflow/mlflow.db --older-than 30d`. Delete runs manually first
 
 


### PR DESCRIPTION
This flow adds the option to sync all payments within a daterange of a certain account. This can be used if an account is added while this server has already been syncing for a while, to backfill the payments in YNAB. 

This flow respects START_SYNC_DATE