### PR TITLE
Bugfix/double payments

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
         {
             "label": "Docker up",
             "type": "shell",
-            "command": "docker compose -f docker/development.yml --env-file ./.docker-env -p bunqynab up --build",
+            "command": "docker compose -f docker/development.yml --env-file ./.docker-env -p bunqynab up",
             "options": {
                 "cwd": "${workspaceFolder}"
             }

--- a/bunq_ynab_connect/flows.py
+++ b/bunq_ynab_connect/flows.py
@@ -61,10 +61,10 @@ def sync_payment_queue() -> None:
 
 
 @flow
-def sync_payment(payment_id: int) -> None:
+def sync_payment(payment_id: int, skip_if_synced: bool) -> None:  # noqa: FBT001
     """Sync a single payment from bunq to YNAB."""
     syncer = PaymentSyncer()
-    syncer.sync_payment(payment_id)
+    syncer.sync_payment(payment_id, skip_if_synced=skip_if_synced)
 
 
 @flow

--- a/bunq_ynab_connect/main.py
+++ b/bunq_ynab_connect/main.py
@@ -49,10 +49,11 @@ def sync_payments() -> None:
 
 @cli.command()
 @click.argument("payment_id", type=int)
-def sync_payment(payment_id: int) -> None:
+@click.argument("skip_if_synced", type=bool, default=True)
+def sync_payment(payment_id: int, skip_if_synced: bool) -> None:  # noqa: FBT001
     """Sync a single payment from bunq to YNAB."""
     syncer = PaymentSyncer()
-    syncer.sync_payment(payment_id)
+    syncer.sync_payment(payment_id, skip_if_synced=skip_if_synced)
 
 
 @cli.command()

--- a/bunq_ynab_connect/prefect.yaml
+++ b/bunq_ynab_connect/prefect.yaml
@@ -48,7 +48,8 @@ deployments:
     version: 2023.08.29.1
     description: Sync one payment by id to Ynab
     entrypoint: flows:sync_payment
-    parameters: {}
+    parameters:
+      skip_if_synced: true
     work_pool:
       name: docker-pool
       work_queue_name: default

--- a/bunq_ynab_connect/sync_bunq_to_ynab/callback_server.py
+++ b/bunq_ynab_connect/sync_bunq_to_ynab/callback_server.py
@@ -34,7 +34,7 @@ async def process_payment(payment: BunqPayment, storage: AbstractStorage) -> Non
     storage.upsert("bunq_payments", [payment.dict()])
     flow_run = await run_deployment(
         name="sync-payment/sync_payment",
-        parameters={"payment_id": payment.id},
+        parameters={"payment_id": payment.id, "skip_if_synced": True},
         timeout=0,
     )
     logger = di[LoggerAdapter]

--- a/bunq_ynab_connect/sync_bunq_to_ynab/payment_queue.py
+++ b/bunq_ynab_connect/sync_bunq_to_ynab/payment_queue.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import datetime
 from logging import LoggerAdapter
 
 from kink import inject
@@ -53,6 +54,15 @@ class PaymentQueue:
             "synced_at": now(),
         }
         self.storage.upsert(self.TABLE_NAME, [data])
+
+    def synced_at(self, payment_id: str) -> datetime | None:
+        item = self.storage.find_one(
+            self.TABLE_NAME, {("payment_id", "eq", payment_id)}
+        )
+        return None if not item else item["synced_at"]
+
+    def is_yet_synced(self, payment_id: str) -> bool:
+        return self.synced_at(payment_id) is not None
 
     def __bool__(self) -> bool:
         """To support the usage of the queue in a while loop."""

--- a/docker/portainer.yaml
+++ b/docker/portainer.yaml
@@ -28,7 +28,7 @@ services:
       - mongodb
     restart: unless-stopped
     networks:
-      - traefik    
+      - traefik
 
   prefect-server:
     image: prefecthq/prefect:2.20.4-python3.12
@@ -96,7 +96,7 @@ services:
     ports:
       - "12005:8080"
     volumes:
-      - ./config:/home/bunqynab/config
+      - bunq_ynab_config:/home/bunqynab/config
     command: "mlserver start /home/bunqynab/config/mlserver"
     networks:
       - traefik    
@@ -116,7 +116,7 @@ services:
     image: index.docker.io/auckebos/bunq-ynab-connect:latest
     container_name: bunqynab_callback_server
     volumes:
-      - ./config:/home/bunqynab/config    
+      - bunq_ynab_config:/home/bunqynab/config
     env_file:
       - stack.env
     command: "uvicorn bunq_ynab_connect.sync_bunq_to_ynab.callback_server:app --host 0.0.0.0"


### PR DESCRIPTION
Add skip_if_synced bool param to sync_payment. Set to true when received by callback.

It seems bunq calls the callback more than once for each mutation. This feature prevents double syncing