### PR TITLE
feat: add category id to ynab request + extra

### DIFF
--- a/bunq_ynab_connect/bootstrap.py
+++ b/bunq_ynab_connect/bootstrap.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import sys
 from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
@@ -25,7 +24,6 @@ from bunq_ynab_connect.helpers.config import (
     CACHE_DIR,
     CONFIG_DIR,
     LOGS_DIR,
-    LOGS_FILE,
     MLSERVER_CONFIG_DIR,
     MLSERVER_PREDICTION_URL_INDEX,
     MLSERVER_REPOSITORY_URL_INDEX,
@@ -47,14 +45,6 @@ def _get_logger(name: str) -> logging.LoggerAdapter:
         logger = get_run_logger()
     except MissingContextError:
         logger = get_logger(name)
-        log_fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        Path.mkdir(LOGS_DIR, exist_ok=True, parents=True)
-        fhandler = logging.FileHandler(filename=LOGS_FILE, mode="a")
-        stdout_handler = logging.StreamHandler(sys.stdout)
-        formatter = logging.Formatter(log_fmt)
-        fhandler.setFormatter(formatter)
-        logger.addHandler(fhandler)
-        logger.addHandler(stdout_handler)
         logger.warning("Bad prefect logger;")
     logger.setLevel(logging.DEBUG)
     return logger

--- a/bunq_ynab_connect/classification/budget_category_encoder.py
+++ b/bunq_ynab_connect/classification/budget_category_encoder.py
@@ -8,20 +8,32 @@ class BudgetCategoryEncoder(BaseEstimator, TransformerMixin):
     """Encoder for the budget categories.
 
     Consumes a list of YnabTransactions and returns a list of integers.
+
+    Attributes
+    ----------
+        encoder: LabelEncoder used to encode the categories
+        id_to_name: dict[str, str]
+            Maps IDs to names. To be able to log the category names later on.
+
     """
 
     encoder: LabelEncoder
+    id_to_name: dict[str, str]
 
     def __init__(self):
         self.encoder = LabelEncoder()
 
     def fit(self, y: list[dict]) -> "BudgetCategoryEncoder":
-        categories = [transaction["category_name"] for transaction in y]
+        categories = [transaction["category_id"] for transaction in y]
+        self.id_to_name = {
+            transaction["category_id"]: transaction["category_name"]
+            for transaction in y
+        }
         self.encoder.fit(categories)
         return self
 
     def transform(self, y: list[dict]) -> list[int]:
-        categories = [transaction["category_name"] for transaction in y]
+        categories = [transaction["category_id"] for transaction in y]
         return self.encoder.transform(categories)
 
     def inverse_transform(self, y: Any) -> list[str]:  # noqa: ANN401

--- a/bunq_ynab_connect/classification/experiments/base_payment_classification_experiment.py
+++ b/bunq_ynab_connect/classification/experiments/base_payment_classification_experiment.py
@@ -88,8 +88,8 @@ class BasePaymentClassificationExperiment:
             y: Array of categories as integers
 
         """
-        X = np.array([t.bunq_payment.dict() for t in transactions])  # noqa: N806
-        y = np.array([t.ynab_transaction.dict() for t in transactions])
+        X = np.array([t.bunq_payment.model_dump() for t in transactions])  # noqa: N806
+        y = np.array([t.ynab_transaction.model_dump() for t in transactions])
         y = self.label_encoder.fit_transform(y)
         return X, y
 

--- a/bunq_ynab_connect/classification/experiments/full_training_experiment.py
+++ b/bunq_ynab_connect/classification/experiments/full_training_experiment.py
@@ -11,9 +11,6 @@ from sklearn.model_selection import (
 )
 
 import mlflow
-from bunq_ynab_connect.classification.deployable_mlflow_model import (
-    DeployableMlflowModel,
-)
 from bunq_ynab_connect.classification.experiments.base_payment_classification_experiment import (  # noqa: E501
     BasePaymentClassificationExperiment,
 )
@@ -63,18 +60,19 @@ class FullTrainingExperiment(BasePaymentClassificationExperiment):
         y_pred = classifier.predict(X_test)
         score = cohen_kappa_score(y_test, y_pred)
         mlflow.log_metric("cohen_kappa", score)
-        mlflow.sklearn.log_model(classifier, "model")
+        mlflow.sklearn.log_model(classifier, "classifier")
         object_to_mlflow(self.label_encoder, "label_encoder")
 
         artifact_uri = Path(mlflow.active_run().info.artifact_uri)
         artifacts = {
-            "model_path": str(artifact_uri / "model"),
+            "model_path": str(artifact_uri / "classifier"),
             "label_encoder_path": str(artifact_uri / "label_encoder"),
         }
         input_example = [X_train[0]]
+        path = Path(__file__).parents[1] / "deployable_mlflow_model.py"
         mlflow.pyfunc.log_model(
-            artifact_path="deployable_model",
-            python_model=DeployableMlflowModel(),
+            artifact_path="model",
+            python_model=path,
             artifacts=artifacts,
             input_example=input_example,
             registered_model_name=self.budget_id,

--- a/docker/development.yml
+++ b/docker/development.yml
@@ -101,10 +101,27 @@ services:
     ports:
       - "12005:8080"
     volumes:
+      - ../bunq_ynab_connect:/home/bunqynab/bunq_ynab_connect    
       - ../config:/home/bunqynab/config
     command: "mlserver start /home/bunqynab/config/mlserver"
     networks:
       - traefik
+
+  # Temporary solution to restart mlserver daily. Since Prefect agent has no access to the docker socket
+  mlserver_restarter:
+    image: docker:cli
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+    command:
+      [
+        "/bin/sh",
+        "-c",
+        "while true; do sleep 86400; docker restart bunqynab_mlserver; done",
+      ]
+    restart: unless-stopped
+    networks:
+      - traefik      
 
   callback:
     build:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -99,6 +99,22 @@ services:
       - ../config:/home/bunqynab/config
     command: "mlserver start /home/bunqynab/config/mlserver"
     networks:
+      - traefik
+
+  # Temporary solution to restart mlserver daily. Since Prefect agent has no access to the docker socket
+  mlserver_restarter:
+    image: docker:cli
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+    command:
+      [
+        "/bin/sh",
+        "-c",
+        "while true; do sleep 86400; docker restart bunqynab_mlserver; done",
+      ]
+    restart: unless-stopped
+    networks:
       - traefik    
 
   callback:

--- a/docker/portainer.yaml
+++ b/docker/portainer.yaml
@@ -99,7 +99,23 @@ services:
       - bunq_ynab_config:/home/bunqynab/config
     command: "mlserver start /home/bunqynab/config/mlserver"
     networks:
-      - traefik    
+      - traefik
+
+  # Temporary solution to restart mlserver daily. Since Prefect agent has no access to the docker socket
+  mlserver_restarter:
+    image: docker:cli
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+    command:
+      [
+        "/bin/sh",
+        "-c",
+        "while true; do sleep 86400; docker restart bunqynab_mlserver; done",
+      ]
+    restart: unless-stopped
+    networks:
+      - traefik          
 
   callback:
     image: index.docker.io/auckebos/bunq-ynab-connect:latest

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -22,4 +22,4 @@ During the `train` flow, a [Trainer](/bunq_ynab_connect/classification/trainer.p
 - Check if the new model is better. Do not transtition it. The new version is stored, but not promoted.
 - Else: Archive the old model, transition the new model to production.
 - Create a config file for MLServer. This config file links to the Production stage of the model for this budget. Hence the URL will not change after first creation.
-- Use the [Model Repository](https://mlserver.readthedocs.io/en/latest/examples/model-repository/README.html) to reload the model.
+- `[Currently not working]` Restart MLServer. MLServer loads the models into memory, therefor if a new model is in the production stage, MLServer will not pick it up until it is restarted. Because the `prefect-agent` container has no access to the Docker CLI on the host, restarting the `mlserver` container fails. This is currently resolved by the [MLServer restarter](/docs/infrastructure.md#mlserver-restarter), which restarts the MLServer container daily.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -40,6 +40,11 @@ The Dockerfile is described by:
 ### MLServer
 `mlserver` is a container that hosts the MLServer. It is used to serve models. It retrieves the Models from the `mlflow` container, and makes makes them available as REST endpoints to other containers in the network (ie the `prefect-agent`). Whenever a payment is to be synced, a request to `mlserver` is made to classify it with the correct model. Swagger docs are available at [http://192.168.0.4:12006/v2/docs#/](http://192.168.0.4:12006/v2/docs#/)
 
+### MLServer restarter
+A temporary solution to the following problem:
+A deployment trains a new model for each budget weekly. If the new model has a better performance then the existing model, it is promoted to Production. MLServer needs to be restarted to load the new model. However, the `prefect-agent` container does not have access to the docker socket on the host, so it cannot restart the `mlserver` container. 
+This container uses the docker cli to restart the `mlserver` container daily. 
+
 ### Callback server
 `callback` allows near-realtime syncing of Bunq Payments to Ynab. It exposes a Fastapi server, and registers itself as a Callback with Bunq. Bunq will POST any payment made to this URL, and the server will sync it to YNAB directly. Without this container, payments are synced hourly, using the [sync flow](./orchestration.md#deployments).
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -9,7 +9,7 @@ The following flows exist:
 - `extract`. Does not run automatically. Extracts all unextracted payments from bunq. The payments are added to the payment queue, which can be processed using the PaymentSyncer, with flow `sync_payement_queue`.
 - `sync_payment_queue`. Does not run automatically. Syncs all unsynced payments in the payment queue to YNAB.
 - `sync`. Runs hourly between hours 6 and 23. Runs `extract` and `sync_payment_queue` in sequence.
-- `train`. Runs on sunday at 02:00. Trains one model for each budget. Before doing so, extracts all payments, and maps them to transactions in Ynab. Runs 2 experiments. The first one selects the model that fits best with some default params. The second one selects the best configuration with a grid search. Deploys the model to MLServer if it performs better than the current model.
+- `train`. Runs on sunday at 02:00. Trains one model for each budget. Before doing so, extracts all payments, and maps them to transactions in Ynab. Runs 2 experiments. The first one selects the model that fits best with some default params. The second one selects the best configuration with a grid search. Deploys the model to MLServer if it performs better than the current model. Note that the trained model is available the next day, since the [MLServer restarter](/docs/infrastructure.md#mlserver-restarter) restarts the MLServer container daily.
 - `sync_payment`. A flow to debug the syncing of a single payment. Can be triggered manually.
 - `exchange_pat`. A flow to exchange the Bunq PAT token for a config file. Should only be used if the external IP of the server has changed, and the Bunq PAT is restricted to the old IP. If this is the case:
     - Create a new PAT in the Bunq app.


### PR DESCRIPTION
- api seems to use category_id instead of category_name by now. update model accordingly.
- upon prediction, insert instead of upsert classification
- re-introducie mlserver-restarter. mlserver repo reload does not correctly reload the model
- use new mlflow model saving: [model-from-code](https://mlflow.org/docs/latest/model/models-from-code.html)
- simplify get_logger