### PR TITLE
fix: prevent double sync

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,3 +1,4 @@
 sudo "./provide_docker_access.sh"
 cd "/home/bunqynab/bunq_ynab_connect"
+prefect gcl create single-payment-sync --limit 1
 python "worker.py"


### PR DESCRIPTION
Rate limit the sync-payment job with allowing at most 1 sync at the time. Upon a second sync, we must be sure the first sync is completed, hence the second call will skip a resync. Without limiting, two syncs will run concurrently, and the payment will be synced twice.